### PR TITLE
Remove bloat from cargo package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 license = "MIT"
 keywords = ["ffi", "no_std", "unsafe", "vec", "vector"]
 categories = ["no-std", "rust-patterns"]
+include = ["src/**/*", "tests/**/*", "LICENSE", "README.md"]
 
 [dependencies]
 


### PR DESCRIPTION
Run cargo-diet, copy config from intaglio.

```
$ cargo diet
┌────────────────────────────────────┬─────────────┐
│ File                               │ Size (Byte) │
├────────────────────────────────────┼─────────────┤
│ .ruby-version                      │           6 │
│ .prettierignore                    │         109 │
│ .yamllint.yaml                     │         138 │
│ tests/version_numbers.rs           │         196 │
│ Gemfile                            │         234 │
│ .github/markdown-link-check.json   │         235 │
│ .prettierrc.yaml                   │         308 │
│ .github/workflows/block-merge.yaml │         315 │
│ .github/dependabot.yml             │         382 │
│ .rubocop.yml                       │         392 │
│ deny.toml                          │         485 │
│ .github/workflows/repo-labels.yaml │         737 │
│ Gemfile.lock                       │         876 │
│ .github/workflows/rustdoc.yaml     │        1024 │
│ .github/workflows/audit.yaml       │        1555 │
│ .gitignore                         │        1859 │
│ .github/workflows/ci.yaml          │        3126 │
│ Rakefile                           │        3163 │
│ .github/labels.yaml                │        3890 │
│ CONTRIBUTING.md                    │        6414 │
└────────────────────────────────────┴─────────────┘
Saved 64% or 25.4 KB in 20 files (of 39.7 KB and 24 files in entire crate)

The following change was made to Cargo.toml:
Diff - removed / added + :
[…skipped 11 lines…]
keywords = ["ffi", "no_std", "unsafe", "vec", "vector"]
categories = ["no-std", "rust-patterns"]
+include = ["src/lib.rs", "LICENSE", "README.md"]

[dependencies]
[…skipped 6 lines…]
```