### PR TITLE
Prepare for v1.0.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-parts"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 description = """

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! raw-parts is `no_std` compatible with a required dependency on [`alloc`].
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/raw-parts/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/raw-parts/1.0.1")]
 
 // Ensure code blocks in `README.md` compile
 #[cfg(doctest)]


### PR DESCRIPTION
Release 1.0.1 of raw-parts.

[`raw-parts` is available on crates.io](https://crates.io/crates/raw-parts/1.0.1).

## Improvements

This release includes improvements to documentation and packaging.

- https://github.com/artichoke/raw-parts/pull/4
- https://github.com/artichoke/raw-parts/pull/5
- https://github.com/artichoke/raw-parts/pull/6