### PR TITLE
Add `rust-version` key to Cargo.toml manifest to declare MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "raw-parts"
 version = "1.0.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
+rust-version = "1.56.0"
 description = """
 Ergonomic wrapper around `Vec::from_raw_parts` and `Vec::into_raw_parts`.
 """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-parts"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.56.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@
 
 //! A wrapper around the decomposed parts of a `Vec<T>`.
 //!
-//! This struct contains the `Vec`'s internal pointer, length, and allocated
-//! capacity.
+//! This crate defines a struct that contains the `Vec`'s internal pointer,
+//! length, and allocated capacity.
 //!
 //! [`RawParts`] makes [`Vec::from_raw_parts`] and [`Vec::into_raw_parts`] easier
 //! to use by giving names to the returned values. This prevents errors from

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! raw-parts is `no_std` compatible with a required dependency on [`alloc`].
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/raw-parts/1.0.1")]
+#![doc(html_root_url = "https://docs.rs/raw-parts/1.0.2")]
 
 // Ensure code blocks in `README.md` compile
 #[cfg(doctest)]


### PR DESCRIPTION
MSRV is already documented in README and is high enough where this field is respected by cargo, so let's add it.

Bump version to 1.0.2 and prepare for release.