### PR TITLE
Bump version to v1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-parts"
-version = "1.0.2"
+version = "1.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2021"
 rust-version = "1.56.0"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-raw-parts = "1.0"
+raw-parts = "1.1"
 ```
 
 Then decompose `Vec<T>`s like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! raw-parts is `no_std` compatible with a required dependency on [`alloc`].
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/raw-parts/1.0.2")]
+#![doc(html_root_url = "https://docs.rs/raw-parts/1.1.0")]
 
 // Ensure code blocks in `README.md` compile
 #[cfg(doctest)]


### PR DESCRIPTION
# Draft Release Notes

Release 1.1.0 of raw-parts.

[`raw-parts` is available on crates.io](https://crates.io/crates/raw-parts/1.1.0).

## Improvements

- Remove bounds on T for Debug, PartialEq and Hash impls https://github.com/artichoke/raw-parts/pull/17

This release includes improvements to documentation and packaging.