### PR TITLE
Prepare for v1.1.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-parts"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-raw-parts = "1.1.1"
+raw-parts = "1.1.2"
 ```
 
 Then decompose `Vec<T>`s like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! raw-parts is `no_std` compatible with a required dependency on [`alloc`].
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/raw-parts/1.1.1")]
+#![doc(html_root_url = "https://docs.rs/raw-parts/1.1.2")]
 
 // Ensure code blocks in `README.md` compile
 #[cfg(doctest)]


### PR DESCRIPTION
Release 1.1.2 of raw-parts.

[`raw-parts` is available on crates.io](https://crates.io/crates/raw-parts/1.1.2).

## Improvements

This release includes improvements to documentation and packaging.

- Set package.metadata.docs.rs metadata in `Cargo.toml` manifest. https://github.com/artichoke/raw-parts/pull/24
- Use precise crate version in `Cargo.toml` snippet in README. https://github.com/artichoke/raw-parts/pull/30