### PR TITLE
Add tests to improve code coverage to 100%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Created by https://www.toptal.com/developers/gitignore/api/vim,rust,ruby
-# Edit at https://www.toptal.com/developers/gitignore?templates=vim,rust,ruby
+
+# Created by https://www.toptal.com/developers/gitignore/api/ruby,rust,vim
+# Edit at https://www.toptal.com/developers/gitignore?templates=ruby,rust,vim
 
 ### Ruby ###
 *.gem
@@ -95,9 +96,12 @@ tags
 # Persistent undo
 [._]*.un~
 
-# End of https://www.toptal.com/developers/gitignore/api/vim,rust,ruby
+# End of https://www.toptal.com/developers/gitignore/api/ruby,rust,vim
 
 # Overrides
 
 # Cargo and other Rust tool configuration lives in a top-level `.config/` directory.
 !/.config/
+# https://github.com/sourcefrog/cargo-mutants/blob/main/.gitignore
+mutants.out
+mutants.out.old

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ include = ["src/**/*", "tests/**/*", "LICENSE", "README.md"]
 [dependencies]
 
 [dev-dependencies]
+# a no_std hasher for tests of `impl Hash for RawParts`
+rustc-hash = { version = "1.1.0", default-features = false }
 
 # Check that crate versions are properly updated in documentation and code when
 # bumping the version.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -441,7 +441,67 @@ mod tests {
     }
 
     #[test]
-    fn hash_pass() {
+    fn hash_fail_pointer() {
+        let mut vec_1 = Vec::with_capacity(100); // capacity is 100
+        vec_1.extend_from_slice(b"123456789"); // length is 9
+        let mut vec_2 = Vec::with_capacity(100); // capacity is 100
+        vec_2.extend_from_slice(b"123456789"); // length is 9
+
+        let raw_parts_1 = RawParts::from_vec(vec_1);
+        let mut hasher = FxHasher::default();
+        raw_parts_1.hash(&mut hasher);
+        let hash_a = hasher.finish();
+
+        let raw_parts_2 = RawParts::from_vec(vec_2);
+        let mut hasher = FxHasher::default();
+        raw_parts_2.hash(&mut hasher);
+        let hash_b = hasher.finish();
+
+        assert_ne!(hash_a, hash_b);
+    }
+
+    #[test]
+    fn hash_fail_capacity() {
+        let mut vec_1 = Vec::with_capacity(100); // capacity is 100
+        vec_1.extend_from_slice(b"123456789"); // length is 9
+        let mut vec_2 = Vec::with_capacity(101); // capacity is 101
+        vec_2.extend_from_slice(b"123456789"); // length is 9
+
+        let raw_parts_1 = RawParts::from_vec(vec_1);
+        let mut hasher = FxHasher::default();
+        raw_parts_1.hash(&mut hasher);
+        let hash_a = hasher.finish();
+
+        let raw_parts_2 = RawParts::from_vec(vec_2);
+        let mut hasher = FxHasher::default();
+        raw_parts_2.hash(&mut hasher);
+        let hash_b = hasher.finish();
+
+        assert_ne!(hash_a, hash_b);
+    }
+
+    #[test]
+    fn hash_fail_length() {
+        let mut vec_1 = Vec::with_capacity(100); // capacity is 100
+        vec_1.extend_from_slice(b"123456789"); // length is 9
+        let mut vec_2 = Vec::with_capacity(100); // capacity is 100
+        vec_2.extend_from_slice(b"12345678"); // length is 8
+
+        let raw_parts_1 = RawParts::from_vec(vec_1);
+        let mut hasher = FxHasher::default();
+        raw_parts_1.hash(&mut hasher);
+        let hash_a = hasher.finish();
+
+        let raw_parts_2 = RawParts::from_vec(vec_2);
+        let mut hasher = FxHasher::default();
+        raw_parts_2.hash(&mut hasher);
+        let hash_b = hasher.finish();
+
+        assert_ne!(hash_a, hash_b);
+    }
+
+    #[test]
+    fn hash_eq_pass() {
         let mut vec = Vec::with_capacity(100); // capacity is 100
         vec.extend_from_slice(b"123456789"); // length is 9
         let raw_parts = RawParts::from_vec(vec);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,6 +289,9 @@ impl<T> RawParts<T> {
 mod tests {
     use alloc::format;
     use alloc::vec::Vec;
+    use core::hash::{Hash, Hasher};
+
+    use rustc_hash::FxHasher;
 
     use crate::RawParts;
 
@@ -435,6 +438,23 @@ mod tests {
             capacity,
         };
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn hash_pass() {
+        let mut vec = Vec::with_capacity(100); // capacity is 100
+        vec.extend_from_slice(b"123456789"); // length is 9
+        let raw_parts = RawParts::from_vec(vec);
+
+        let mut hasher = FxHasher::default();
+        raw_parts.hash(&mut hasher);
+        let hash_a = hasher.finish();
+
+        let mut hasher = FxHasher::default();
+        raw_parts.hash(&mut hasher);
+        let hash_b = hasher.finish();
+
+        assert_eq!(hash_a, hash_b);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,6 +336,34 @@ mod tests {
     }
 
     #[test]
+    fn from_sets_ptr() {
+        let mut vec = Vec::with_capacity(100); // capacity is 100
+        vec.extend_from_slice(b"123456789"); // length is 9
+        let ptr = vec.as_mut_ptr();
+
+        let raw_parts = RawParts::from(vec);
+        assert_eq!(raw_parts.ptr, ptr);
+    }
+
+    #[test]
+    fn from_sets_length() {
+        let mut vec = Vec::with_capacity(100); // capacity is 100
+        vec.extend_from_slice(b"123456789"); // length is 9
+
+        let raw_parts = RawParts::from(vec);
+        assert_eq!(raw_parts.length, 9);
+    }
+
+    #[test]
+    fn from_sets_capacity() {
+        let mut vec = Vec::with_capacity(100); // capacity is 100
+        vec.extend_from_slice(b"123456789"); // length is 9
+
+        let raw_parts = RawParts::from(vec);
+        assert_eq!(raw_parts.capacity, 100);
+    }
+
+    #[test]
     fn debug_test() {
         let mut vec = Vec::with_capacity(100); // capacity is 100
         vec.extend_from_slice(b"123456789"); // length is 9


### PR DESCRIPTION
This PR adds a dev dependency on `rustc-hash` to pull in a `no_std` hasher.

Fixes #49.
Fixes #56.