### PR TITLE
Prepare for v2.0.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-parts"
-version = "1.1.2"
+version = "2.0.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-raw-parts = "1.1.2"
+raw-parts = "2.0.0"
 ```
 
 Then decompose `Vec<T>`s like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! raw-parts is `no_std` compatible with a required dependency on [`alloc`].
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/raw-parts/1.1.2")]
+#![doc(html_root_url = "https://docs.rs/raw-parts/2.0.0")]
 
 extern crate alloc;
 


### PR DESCRIPTION
Release 2.0.0 of raw-parts.

[`raw-parts` is available on crates.io](https://crates.io/crates/raw-parts/2.0.0).

## Breaking Changes

- Make `RawParts::into_vec` a regular method. https://github.com/artichoke/raw-parts/pull/87

## Improvements

This release includes improvements to documentation and packaging.

- Add tests to improve code coverage to 100%. https://github.com/artichoke/raw-parts/pull/84
- Code quality improvements on `RawParts::from_vec`. https://github.com/artichoke/raw-parts/pull/85
- Resync safety docs on `RawParts::into_vec` from upstream. https://github.com/artichoke/raw-parts/pull/86

And many improvements to the build infrastructure.