### PR TITLE
Replace rustc-hash with fnv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = ["src/**/*", "tests/**/*", "LICENSE", "README.md"]
 
 [dev-dependencies]
 # a no_std hasher for tests of `impl Hash for RawParts`
-rustc-hash = { version = "1.1.0", default-features = false }
+fnv = { version = "1.0.6", default-features = false }
 
 # Check that crate versions are properly updated in documentation and code when
 # bumping the version.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@ mod tests {
     use alloc::vec::Vec;
     use core::hash::{Hash, Hasher};
 
-    use rustc_hash::FxHasher;
+    use fnv::FnvHasher;
 
     use crate::RawParts;
 
@@ -462,12 +462,12 @@ mod tests {
         vec_2.extend_from_slice(b"123456789"); // length is 9
 
         let raw_parts_1 = RawParts::from_vec(vec_1);
-        let mut hasher = FxHasher::default();
+        let mut hasher = FnvHasher::default();
         raw_parts_1.hash(&mut hasher);
         let hash_a = hasher.finish();
 
         let raw_parts_2 = RawParts::from_vec(vec_2);
-        let mut hasher = FxHasher::default();
+        let mut hasher = FnvHasher::default();
         raw_parts_2.hash(&mut hasher);
         let hash_b = hasher.finish();
 
@@ -482,12 +482,12 @@ mod tests {
         vec_2.extend_from_slice(b"123456789"); // length is 9
 
         let raw_parts_1 = RawParts::from_vec(vec_1);
-        let mut hasher = FxHasher::default();
+        let mut hasher = FnvHasher::default();
         raw_parts_1.hash(&mut hasher);
         let hash_a = hasher.finish();
 
         let raw_parts_2 = RawParts::from_vec(vec_2);
-        let mut hasher = FxHasher::default();
+        let mut hasher = FnvHasher::default();
         raw_parts_2.hash(&mut hasher);
         let hash_b = hasher.finish();
 
@@ -502,12 +502,12 @@ mod tests {
         vec_2.extend_from_slice(b"12345678"); // length is 8
 
         let raw_parts_1 = RawParts::from_vec(vec_1);
-        let mut hasher = FxHasher::default();
+        let mut hasher = FnvHasher::default();
         raw_parts_1.hash(&mut hasher);
         let hash_a = hasher.finish();
 
         let raw_parts_2 = RawParts::from_vec(vec_2);
-        let mut hasher = FxHasher::default();
+        let mut hasher = FnvHasher::default();
         raw_parts_2.hash(&mut hasher);
         let hash_b = hasher.finish();
 
@@ -520,11 +520,11 @@ mod tests {
         vec.extend_from_slice(b"123456789"); // length is 9
         let raw_parts = RawParts::from_vec(vec);
 
-        let mut hasher = FxHasher::default();
+        let mut hasher = FnvHasher::default();
         raw_parts.hash(&mut hasher);
         let hash_a = hasher.finish();
 
-        let mut hasher = FxHasher::default();
+        let mut hasher = FnvHasher::default();
         raw_parts.hash(&mut hasher);
         let hash_b = hasher.finish();
 


### PR DESCRIPTION
rustc-hash v2.0.0 does not play nicely with Cargo 1.56.0's dependency resolver. Performance is not critical for these code coverage tests, so use a more stable dependency.

Obsoletes #129.