### PR TITLE
Remove markdown link check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,26 +111,24 @@ tasks by running:
 
 ```console
 $ bundle exec rake --tasks
-rake build                        # Build Rust workspace
-rake bundle:audit:check           # Checks the Gemfile.lock for insecure dependencies
-rake bundle:audit:update          # Updates the bundler-audit vulnerability database
-rake doc                          # Generate Rust API documentation
-rake doc:open                     # Generate Rust API documentation and open it in a web browser
-rake fmt                          # Format sources
-rake fmt:rust                     # Format Rust sources with rustfmt
-rake fmt:text                     # Format text, YAML, and Markdown sources with prettier
-rake format                       # Format sources
-rake format:rust                  # Format Rust sources with rustfmt
-rake format:text                  # Format text, YAML, and Markdown sources with prettier
-rake lint                         # Lint sources
-rake lint:clippy                  # Lint Rust sources with Clippy
-rake lint:clippy:restriction      # Lint Rust sources with Clippy restriction pass (unenforced lints)
-rake lint:rubocop                 # Run RuboCop
-rake lint:rubocop:autocorrect     # Auto-correct RuboCop offenses
-rake release:markdown_link_check  # Check for broken links in markdown files
-rake test                         # Run raw-parts unit tests
-rake unicode:build                # Rebuild Rust generated Rust sources from Unicode data
-rake unicode:update               # Update Unicode data
+rake build                         # Build Rust workspace
+rake bundle:audit:check            # Checks the Gemfile.lock for insecure dependencies
+rake bundle:audit:update           # Updates the bundler-audit vulnerability database
+rake doc                           # Generate Rust API documentation
+rake doc:open                      # Generate Rust API documentation and open it in a web browser
+rake fmt                           # Format sources
+rake fmt:rust                      # Format Rust sources with rustfmt
+rake fmt:text                      # Format text, YAML, and Markdown sources with prettier
+rake format                        # Format sources
+rake format:rust                   # Format Rust sources with rustfmt
+rake format:text                   # Format text, YAML, and Markdown sources with prettier
+rake lint                          # Lint sources
+rake lint:clippy                   # Lint Rust sources with Clippy
+rake lint:clippy:restriction       # Lint Rust sources with Clippy restriction pass (unenforced lints)
+rake lint:rubocop                  # Run RuboCop
+rake lint:rubocop:autocorrect      # Autocorrect RuboCop offenses (only when it's safe)
+rake lint:rubocop:autocorrect_all  # Autocorrect RuboCop offenses (safe and unsafe)
+rake test                          # Run raw-parts unit tests
 ```
 
 To lint Ruby sources, raw-parts uses [RuboCop]. RuboCop runs as part of the

--- a/Rakefile
+++ b/Rakefile
@@ -89,41 +89,4 @@ task :test do
   sh 'cargo test --workspace'
 end
 
-namespace :unicode do
-  desc 'Rebuild Rust generated Rust sources from Unicode data'
-  task :build do
-    ruby 'scripts/gen_case_lookups.rb'
-  end
-
-  desc 'Update Unicode data'
-  task :update do
-    open('https://www.unicode.org/Public/UCD/latest/ucd/CaseFolding.txt') do |data|
-      File.open('CaseFolding.txt', 'w') do |file|
-        data.each_line do |line|
-          file.write(line)
-        end
-      end
-    end
-  end
-end
-
 Bundler::Audit::Task.new
-
-namespace :release do
-  link_check_files = FileList.new('**/*.md') do |f|
-    f.exclude('node_modules/**/*')
-    f.exclude('**/target/**/*')
-    f.exclude('**/vendor/*/**/*')
-    f.include('*.md')
-    f.include('**/vendor/*.md')
-  end
-
-  link_check_files.sort.uniq.each do |markdown|
-    desc 'Check for broken links in markdown files'
-    task markdown_link_check: markdown do
-      command = ['npx', 'markdown-link-check', '--config', '.github/markdown-link-check.json', markdown]
-      sh command.shelljoin
-      sleep(rand(1..5))
-    end
-  end
-end


### PR DESCRIPTION
This CI job is incredibly flaky and provides little value. Remove it to reduce maintenance burden.

Followup to #147 which was prematurely merged.