### PR TITLE
Bump crate version to 2.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-parts"
-version = "2.2.0"
+version = "2.2.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-raw-parts = "2.2.0"
+raw-parts = "2.2.1"
 ```
 
 Then decompose `Vec<T>`s like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! raw-parts is `no_std` compatible with a required dependency on [`alloc`].
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/raw-parts/2.2.0")]
+#![doc(html_root_url = "https://docs.rs/raw-parts/2.2.1")]
 
 extern crate alloc;
 


### PR DESCRIPTION
## Summary
- bump crate version in Cargo.toml from 2.2.0 to 2.2.1
- update README dependency snippet to 2.2.1
- update docs.rs html_root_url in src/lib.rs to 2.2.1

## Validation
- cargo test --workspace