### PR TITLE
Fix rustdoc build and prepare v2.2.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-parts"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-raw-parts = "2.2.1"
+raw-parts = "2.2.2"
 ```
 
 Then decompose `Vec<T>`s like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 //
 // This approach is borrowed from tokio.
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, feature(doc_alias))]
 
 //! A wrapper around the decomposed parts of a `Vec<T>`.
 //!
@@ -53,7 +52,7 @@
 //! raw-parts is `no_std` compatible with a required dependency on [`alloc`].
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/raw-parts/2.2.1")]
+#![doc(html_root_url = "https://docs.rs/raw-parts/2.2.2")]
 
 extern crate alloc;
 


### PR DESCRIPTION
## Summary
- remove the stale docsrs doc_alias feature gate that now fails under -D warnings
- bump the crate and docs metadata from 2.2.1 to 2.2.2
- update the README dependency snippet for the patch release

## Verification
- cargo test
- cargo +nightly test
- RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links --cfg docsrs" cargo +nightly doc --no-deps
- cargo package --allow-dirty