### PR TITLE
[codex] Prepare 2.2.3 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-parts"
-version = "2.2.2"
+version = "2.2.3"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-raw-parts = "2.2.2"
+raw-parts = "2.2.3"
 ```
 
 Then decompose `Vec<T>`s like:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raw-parts"
-version = "2.2.2"
+version = "2.2.3"
 description = "Ergonomic wrapper around Vec raw parts"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //! raw-parts is `no_std` compatible with a required dependency on [`alloc`].
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/raw-parts/2.2.2")]
+#![doc(html_root_url = "https://docs.rs/raw-parts/2.2.3")]
 
 extern crate alloc;
 
@@ -88,6 +88,38 @@ use core::mem::ManuallyDrop;
 ///     raw_parts.into_vec()
 /// };
 /// assert_eq!(rebuilt, [4294967295, 0, 1]);
+/// ```
+///
+/// `RawParts<T>` must not accidentally gain `Send` or `Sync` for element types
+/// that do not support crossing thread boundaries.
+///
+/// ```compile_fail
+/// use raw_parts::RawParts;
+/// use std::rc::Rc;
+///
+/// fn assert_send<T: Send>() {}
+/// fn assert_sync<T: Sync>() {}
+///
+/// fn main() {
+///     assert_send::<RawParts<Rc<()>>>();
+///     assert_sync::<RawParts<Rc<()>>>();
+/// }
+/// ```
+///
+/// `RawParts<T>` must also preserve the lifetime of borrowed element types
+/// rather than allowing them to widen to `'static`.
+///
+/// ```compile_fail
+/// use raw_parts::RawParts;
+///
+/// fn need_static(_: RawParts<&'static str>) {}
+///
+/// fn main() {
+///     let s = String::from("hi");
+///     let v = vec![s.as_str()];
+///     let raw = RawParts::from_vec(v);
+///     need_static(raw);
+/// }
 /// ```
 pub struct RawParts<T> {
     /// A non-null pointer to a buffer of `T`.

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "raw-parts"
-version = "2.2.2"
+version = "2.2.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

This PR adds negative doctest coverage for two soundness-adjacent properties of `RawParts<T>` and prepares the next patch release by bumping the package version to `2.2.3` everywhere the repo encodes it.

## What changed

- add `compile_fail` doctests proving `RawParts<Rc<()>>` does not become `Send`/`Sync`
- add a `compile_fail` doctest proving borrowed element lifetimes do not widen to `'static`
- bump the Rust crate, docs URL, README snippet, and Python packaging metadata from `2.2.2` to `2.2.3`

## Why

The new doctests turn the red-team assessment conclusions into checked regressions, so future refactors are less likely to accidentally change compiler-derived safety properties.

The version bump prepares a patch release that carries those hardening checks.

## Validation

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #206
